### PR TITLE
Allow users to specify their own custom callsettings when creating a service.

### DIFF
--- a/src/Lib/GoogleAdsClient.cs
+++ b/src/Lib/GoogleAdsClient.cs
@@ -68,8 +68,23 @@ namespace Google.Ads.GoogleAds.Lib
                 where TServiceSetting : ServiceSettingsBase, new()
                 where TService : GoogleAdsServiceClientBase
         {
+            return GetService(serviceTemplate, null);
+        }
+
+        /// <summary>
+        /// Gets an instance of the specified service.
+        /// </summary>
+        /// <param name="serviceTemplate">The service template.</param>
+        /// <param name="callSettings">The call settings.</param>
+        /// <returns>A service instance.</returns>
+        public TService GetService<TService, TServiceSetting>(
+            ServiceTemplate<TService, TServiceSetting> serviceTemplate,
+            CallSettings callSettings)
+                where TServiceSetting : ServiceSettingsBase, new()
+                where TService : GoogleAdsServiceClientBase
+        {
             GoogleAdsServiceClientFactory factory = new GoogleAdsServiceClientFactory();
-            TService service = factory.GetService(serviceTemplate, Config);
+            TService service = factory.GetService(serviceTemplate, callSettings, Config);
             service.ServiceContext.Client = this;
             return service;
         }


### PR DESCRIPTION
This allows users to customize timeouts as they see fit.