### PR TITLE
Fixing AdGroupAd status to be Enabled

### DIFF
--- a/examples/HotelAds/AddHotelAd.cs
+++ b/examples/HotelAds/AddHotelAd.cs
@@ -289,7 +289,7 @@ namespace Google.Ads.GoogleAds.Examples.V2
                 },
                 // Set the ad group.
                 AdGroup = adGroupResourceName,
-                Status = AdGroupAdStatus.Paused
+                Status = AdGroupAdStatus.Enabled
             };
 
             // Create an ad group ad operation.

--- a/examples/HotelAds/AddHotelAd.cs
+++ b/examples/HotelAds/AddHotelAd.cs
@@ -289,6 +289,9 @@ namespace Google.Ads.GoogleAds.Examples.V2
                 },
                 // Set the ad group.
                 AdGroup = adGroupResourceName,
+                // Set the ad group ad to enabled.  Setting this to paused will cause an error
+                // for hotel campaigns.  For hotels pausing should happen at either the ad group or
+                // campaign level.  
                 Status = AdGroupAdStatus.Enabled
             };
 


### PR DESCRIPTION
There was a change for Hotels that causes an error when setting `AdGroupAd` to `PAUSED` and should always be `ENABLED`.  Setting `AdGroupAd`'s status to `PAUSED` will now throw a `OPERATION_NOT_PERMITTED_FOR_CAMPAIGN_TYPE`, this is expected as the status for `AdGroupAd` for Hotel campaigns should always be `ENABLED`.