### PR TITLE
Remove extra characters in line example

### DIFF
--- a/src/App.config
+++ b/src/App.config
@@ -82,7 +82,7 @@
          specify this later in code if your application uses  multiple manager account OAuth pairs.
     -->
     <!--
-        <add key = 'LoginCustomerId' value = 'INSERT_LOGIN_CUSTOMER_ID_HERE' />/n/n
+        <add key = 'LoginCustomerId' value = 'INSERT_LOGIN_CUSTOMER_ID_HERE' />
     -->
   </GoogleAdsApi>
   <startup>


### PR DESCRIPTION
It makes the config parsing fails with the obscure error `System.Configuration.ConfigurationErrorsException: Only elements allowed.` when we remove the `<!--` and `-->`