### PR TITLE
Do not set a default value of CancellationToken. 

### DIFF
--- a/src/V10/ServiceHelperMethods.cs
+++ b/src/V10/ServiceHelperMethods.cs
@@ -96,7 +96,7 @@ namespace Google.Ads.GoogleAds.V10.Services
             {
                 var responseStream = searchStream.GetResponseStream();
                 bool emptyResult = true;
-                while (await responseStream.MoveNextAsync(CancellationToken.None))
+                while (await responseStream.MoveNextAsync())
                 {
                     emptyResult = false;
                     SearchGoogleAdsStreamResponse resp = responseStream.Current;

--- a/src/V8/ServiceHelperMethods.cs
+++ b/src/V8/ServiceHelperMethods.cs
@@ -96,7 +96,7 @@ namespace Google.Ads.GoogleAds.V8.Services
             {
                 var responseStream = searchStream.GetResponseStream();
                 bool emptyResult = true;
-                while (await responseStream.MoveNextAsync(CancellationToken.None))
+                while (await responseStream.MoveNextAsync())
                 {
                     emptyResult = false;
                     SearchGoogleAdsStreamResponse resp = responseStream.Current;

--- a/src/V9/ServiceHelperMethods.cs
+++ b/src/V9/ServiceHelperMethods.cs
@@ -96,7 +96,7 @@ namespace Google.Ads.GoogleAds.V9.Services
             {
                 var responseStream = searchStream.GetResponseStream();
                 bool emptyResult = true;
-                while (await responseStream.MoveNextAsync(CancellationToken.None))
+                while (await responseStream.MoveNextAsync())
                 {
                     emptyResult = false;
                     SearchGoogleAdsStreamResponse resp = responseStream.Current;


### PR DESCRIPTION
This allows user to set a cancellationtoken on the callsettings instead. Fixes https://github.com/googleads/google-ads-dotnet/issues/360