### PR TITLE
fix: LinkManagerToClient

### DIFF
--- a/Google.Ads.GoogleAds/examples/AccountManagement/LinkManagerToClient.cs
+++ b/Google.Ads.GoogleAds/examples/AccountManagement/LinkManagerToClient.cs
@@ -190,7 +190,7 @@ namespace Google.Ads.GoogleAds.Examples.V11
                 managerCustomerId.ToString(), query).First();
 
             // Gets the ID and resource name associated to the manager link found.
-            long managerLinkId = result.CustomerManagerLink.ManagerLinkId;
+            long managerLinkId = result.CustomerClientLink.ManagerLinkId;
             string managerLinkResourceName = ResourceNames.CustomerManagerLink(
                 clientCustomerId, managerCustomerId, managerLinkId);
             // Prints the result.
@@ -213,7 +213,7 @@ namespace Google.Ads.GoogleAds.Examples.V11
             CustomerManagerLinkServiceClient customerManagerLinkService =
                 client.GetService(Services.V11.CustomerManagerLinkService);
 
-            // Create a client with the manager customer ID as login customer ID.
+            // Create a client with the client customer ID as login customer ID.
             client.Config.LoginCustomerId = clientCustomerId.ToString();
 
             // Creates the customer manager link with the updated status.


### PR DESCRIPTION
I was doing the integration following the documentation https://developers.google.com/google-ads/api/docs/account-management/linking-manager-accounts and found the following:

1. The query is being done in `customer_client_link` table so the property to be accessed needs to be CustomerClientLink instead of CustomerManagerLink
![image](https://user-images.githubusercontent.com/32345703/182978394-a0ccc1eb-d643-43da-ad51-c9e52bbf2bdf.png)

2. The `clientCustomerId` is being used so we need to use `client customer ID` instead of `manager customer ID`
![image](https://user-images.githubusercontent.com/32345703/182978583-0a1d5a8b-d3ff-4622-994a-e55f8c7ebfc7.png)



