### PR TITLE
Remove the usage of eCPC bidding because of its deprecation

### DIFF
--- a/Google.Ads.GoogleAds/examples/ShoppingAds/AddShoppingProductAd.cs
+++ b/Google.Ads.GoogleAds/examples/ShoppingAds/AddShoppingProductAd.cs
@@ -234,13 +234,17 @@ namespace Google.Ads.GoogleAds.Examples.V15
                 // targeting and the ads are ready to serve
                 Status = CampaignStatus.Paused,
 
-                // Sets the bidding strategy to Manual CPC (with eCPC enabled)
+                // Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for standard
+                // Shopping campaigns is deprecated. If eCPC is set to true, Google Ads ignores the
+                // setting and behaves as if the setting was false. See this blog post for more
+                // information:
+                // https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
                 // Recommendation: Use one of the automated bidding strategies for Shopping
                 // campaigns to help you optimize your advertising spend. More information can be
                 // found here: https://support.google.com/google-ads/answer/6309029
                 ManualCpc = new ManualCpc()
                 {
-                    EnhancedCpcEnabled = true
+                    EnhancedCpcEnabled = false
                 },
 
                 // Sets the budget.


### PR DESCRIPTION
To align with the [code example change](https://github.com/googleads/google-ads-java/pull/742) requested for the Java client library.

As seen in this [blog announcement](https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html), any Shopping campaigns using Enhanced cost-per-click (eCPC) will behave as if they are using Manual cost-per-click (CPC) bidding.

Because of the change, I'm updating the examples related to the announcement to reflect the new recommended practice.