### PR TITLE
Add new recommendation devsite tags

### DIFF
--- a/Google.Ads.GoogleAds/examples/Recommendations/DetectAndApplyRecommendations.cs
+++ b/Google.Ads.GoogleAds/examples/Recommendations/DetectAndApplyRecommendations.cs
@@ -132,16 +132,9 @@ namespace Google.Ads.GoogleAds.Examples.V16
                                     "{keyword.MatchType}");
                             }
 
-                            // [START build_apply_recommendation_operation]
-                            operations.Add(new ApplyRecommendationOperation()
-                            {
-                                // If you have a recommendation_id instead of the resource_name
-                                // you can create a resource name from it like this:
-                                // string recommendationResourceName =
-                                //    ResourceNames.Recommendation(customerId, recommendationId)
-                                ResourceName = recommendation.ResourceName
-                            });
-                            // [END build_apply_recommendation_operation]
+                            operations.Add(
+                                BuildApplyRecommendationOperation(recommendation.ResourceName)
+                            );
                         }
                     }
                 );
@@ -157,8 +150,44 @@ namespace Google.Ads.GoogleAds.Examples.V16
             // [END detect_keyword_recommendations]
         }
 
+        // [START build_apply_recommendation_operation]
+        private ApplyRecommendationOperation BuildApplyRecommendationOperation(
+            string recommendationResourceName
+        )
+        {
+            // If you have a recommendation_id instead of the resource_name you can create a
+            // resource name from it like this:
+            // string recommendationResourceName =
+            //    ResourceNames.Recommendation(customerId, recommendationId)
+
+            // Each recommendation type has optional parameters to override the recommended values.
+            // This is an example to override a recommended ad when a TextAdRecommendation is
+            // applied.
+            // For details, please read
+            // https://developers.google.com/google-ads/api/reference/rpc/latest/ApplyRecommendationOperation.
+            /*
+            Ad overridingAd = new Ad()
+            {
+                Id = "INSERT_AD_ID_AS_LONG_HERE"
+            };
+            applyRecommendationOperation.TextAd = new TextAdParameters()
+            {
+                Ad = overridingAd
+            };
+            */
+
+            ApplyRecommendationOperation applyRecommendationOperation =
+            new ApplyRecommendationOperation()
+            {
+                ResourceName = recommendationResourceName
+            };
+
+            return applyRecommendationOperation;
+        }
+        // [END build_apply_recommendation_operation]
+
         /// <summary>
-        /// Applies a list of recommendation.
+        /// Applies a list of recommendations.
         /// </summary>
         /// <param name="client">The Google Ads client.</param>
         /// <param name="customerId">The customer ID for which the call is made.</param>

--- a/Google.Ads.GoogleAds/examples/Recommendations/DetectAndApplyRecommendations.cs
+++ b/Google.Ads.GoogleAds/examples/Recommendations/DetectAndApplyRecommendations.cs
@@ -96,6 +96,7 @@ namespace Google.Ads.GoogleAds.Examples.V16
         /// <param name="customerId">The customer ID for which the call is made.</param>
         public void Run(GoogleAdsClient client, long customerId)
         {
+            // [START detect_keyword_recommendations]
             // Get the GoogleAdsServiceClient.
             GoogleAdsServiceClient googleAdsService = client.GetService(
                 Services.V16.GoogleAdsService);
@@ -131,6 +132,7 @@ namespace Google.Ads.GoogleAds.Examples.V16
                                     "{keyword.MatchType}");
                             }
 
+                            // [START build_apply_recommendation_operation]
                             operations.Add(new ApplyRecommendationOperation()
                             {
                                 // If you have a recommendation_id instead of the resource_name
@@ -139,6 +141,7 @@ namespace Google.Ads.GoogleAds.Examples.V16
                                 //    ResourceNames.Recommendation(customerId, recommendationId)
                                 ResourceName = recommendation.ResourceName
                             });
+                            // [END build_apply_recommendation_operation]
                         }
                     }
                 );
@@ -151,6 +154,7 @@ namespace Google.Ads.GoogleAds.Examples.V16
                 Console.WriteLine($"Request ID: {e.RequestId}");
                 throw;
             }
+            // [END detect_keyword_recommendations]
         }
 
         /// <summary>

--- a/Google.Ads.GoogleAds/examples/Recommendations/DismissRecommendation.cs
+++ b/Google.Ads.GoogleAds/examples/Recommendations/DismissRecommendation.cs
@@ -16,10 +16,8 @@ using CommandLine;
 using Google.Ads.Gax.Examples;
 using Google.Ads.GoogleAds.Lib;
 using Google.Ads.GoogleAds.V16.Errors;
-using Google.Ads.GoogleAds.V16.Resources;
 using Google.Ads.GoogleAds.V16.Services;
 using System;
-using System.Collections.Generic;
 using static Google.Ads.GoogleAds.V16.Services.DismissRecommendationRequest.Types;
 using static Google.Ads.GoogleAds.V16.Services.DismissRecommendationResponse.Types;
 


### PR DESCRIPTION
Adds two new devsite tags: `build_apply_recommendation_operation` and `detect_keyword_recommendations`

See https://github.com/googleads/google-ads-perl/pull/124 and cl/620247165

note: Because of how the code is written on this example the `build_apply_recommendation_operation` is a bit different than the other client libs