### PR TITLE
Bump the Google.Ads.GoogleAds.Extensions version number for a release

### DIFF
--- a/Google.Ads.GoogleAds.Extensions/src/Google.Ads.GoogleAds.Extensions.csproj
+++ b/Google.Ads.GoogleAds.Extensions/src/Google.Ads.GoogleAds.Extensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Title>Google Ads API Dotnet Client Library Extensions</Title>
     <PackageId>Google.Ads.GoogleAds.Extensions</PackageId>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <Description>This library provides you with extensions for the Google Ads API client library. The Google Ads API is the modern programmatic interface to Google Ads. See https://developers.google.com/google-ads/api to learn more about Google Ads API.</Description>
     <PackageReleaseNotes>https://github.com/googleads/google-ads-dotnet/blob/master/ChangeLog</PackageReleaseNotes>
     <PackageTags>GoogleAds Google</PackageTags>
@@ -31,8 +31,8 @@
     <IncludeSource>true</IncludeSource>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>2.0.2</AssemblyVersion>
-    <FileVersion>2.0.2</FileVersion>
+    <AssemblyVersion>2.0.3</AssemblyVersion>
+    <FileVersion>2.0.3</FileVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Google.Ads.GoogleAds/examples/Google.Ads.GoogleAds.Examples.csproj
+++ b/Google.Ads.GoogleAds/examples/Google.Ads.GoogleAds.Examples.csproj
@@ -36,7 +36,7 @@
    <!-- Include local projects over nuget dependencies if available -->
     <PackageReference Condition="!Exists('..\src\Google.Ads.GoogleAds.csproj')" Include="Google.Ads.GoogleAds" Version="21.1.1" />
     <ProjectReference Condition="Exists('..\src\Google.Ads.GoogleAds.csproj')" Include="..\src\Google.Ads.GoogleAds.csproj" />
-    <PackageReference Condition="!Exists('..\..\Google.Ads.GoogleAds.Extensions\src\Google.Ads.GoogleAds.Extensions.csproj')" Include="Google.Ads.GoogleAds.Extensions" Version="2.0.2" />
+    <PackageReference Condition="!Exists('..\..\Google.Ads.GoogleAds.Extensions\src\Google.Ads.GoogleAds.Extensions.csproj')" Include="Google.Ads.GoogleAds.Extensions" Version="2.0.3" />
     <ProjectReference Condition="Exists('..\..\Google.Ads.GoogleAds.Extensions\src\Google.Ads.GoogleAds.Extensions.csproj')" Include="..\..\Google.Ads.GoogleAds.Extensions\src\Google.Ads.GoogleAds.Extensions.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Note that just the extensions package needs to be released, so there's no need to update the changelog file.