### PR TITLE
Remove the reference for setting Customer Match membership to no expiration

### DIFF
--- a/Google.Ads.GoogleAds/examples/Remarketing/AddCustomerMatchUserList.cs
+++ b/Google.Ads.GoogleAds/examples/Remarketing/AddCustomerMatchUserList.cs
@@ -208,8 +208,8 @@ namespace Google.Ads.GoogleAds.Examples.V19
                 Name = $"Customer Match list# {ExampleUtilities.GetShortRandomString()}",
                 Description = "A list of customers that originated from email and physical" +
                     " addresses",
-                // Customer Match user lists can use a membership life span of 10000 to
-                // indicate unlimited; otherwise normal values apply.
+                // Membership life span must be between 0 and 540 days inclusive. See:
+                // https://developers.google.com/google-ads/api/reference/rpc/latest/UserList#membership_life_span
                 // Sets the membership life span to 30 days.
                 MembershipLifeSpan = 30,
                 CrmBasedUserList = new CrmBasedUserListInfo()


### PR DESCRIPTION
As announced in [this blog post](https://ads-developers.googleblog.com/2025/02/update-to-customer-match-membership.html), we will soon disallow setting `membership_life_span` to no expiration.

Updated the comment to reflect this change.