### PR TITLE
Remove explicit targeting for net6.0

### DIFF
--- a/Google.Ads.Gax/src/Google.Ads.Gax.csproj
+++ b/Google.Ads.Gax/src/Google.Ads.Gax.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <!-- build properties -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472;net8.0</TargetFrameworks>
     <AssemblyName>Google.Ads.Gax</AssemblyName>
     <RootNamespace>Google.Ads.Gax</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/Google.Ads.Gax/tests/Google.Ads.Gax.Tests.csproj
+++ b/Google.Ads.Gax/tests/Google.Ads.Gax.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Google.Ads.Gax.Tests</RootNamespace>
     <AssemblyName>Google.Ads.Gax.Tests</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Google.Ads.GoogleAds.Core/src/Google.Ads.GoogleAds.Core.csproj
+++ b/Google.Ads.GoogleAds.Core/src/Google.Ads.GoogleAds.Core.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <!-- build properties -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472;net8.0</TargetFrameworks>
     <AssemblyName>Google.Ads.GoogleAds.Core</AssemblyName>
     <RootNamespace>Google.Ads.GoogleAds</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/Google.Ads.GoogleAds.Core/tests/Google.Ads.GoogleAds.Core.Tests.csproj
+++ b/Google.Ads.GoogleAds.Core/tests/Google.Ads.GoogleAds.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Google.Ads.GoogleAds.Tests</RootNamespace>
     <AssemblyName>Google.Ads.GoogleAds.Core.Tests</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Google.Ads.GoogleAds.Extensions/src/Google.Ads.GoogleAds.Extensions.csproj
+++ b/Google.Ads.GoogleAds.Extensions/src/Google.Ads.GoogleAds.Extensions.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <!-- build properties -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472;net8.0</TargetFrameworks>
     <AssemblyName>Google.Ads.GoogleAds.Config</AssemblyName>
     <RootNamespace>Google.Ads.GoogleAds</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/Google.Ads.GoogleAds.Extensions/tests/Google.Ads.GoogleAds.Extensions.Tests.csproj
+++ b/Google.Ads.GoogleAds.Extensions/tests/Google.Ads.GoogleAds.Extensions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Google.Ads.GoogleAds.Extensions.Tests</RootNamespace>
     <AssemblyName>Google.Ads.GoogleAds.Extensions.Tests</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Google.Ads.GoogleAds/examples/Authentication/AuthenticateInAspNetCoreApplication/AuthenticateInAspNetCoreApplication.csproj
+++ b/Google.Ads.GoogleAds/examples/Authentication/AuthenticateInAspNetCoreApplication/AuthenticateInAspNetCoreApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Google.Ads.GoogleAds.Examples</RootNamespace>
     <AssemblyName>AuthenticateInAspNetCoreApplication</AssemblyName>
     <DebugType>pdbonly</DebugType>

--- a/Google.Ads.GoogleAds/examples/Authentication/GenerateUserCredentials/GenerateUserCredentials.csproj
+++ b/Google.Ads.GoogleAds/examples/Authentication/GenerateUserCredentials/GenerateUserCredentials.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Title>GenerateUserCredentials - Google Ads API Dotnet Client Library</Title>
     <PackageId>Google.Ads.GoogleAds.GenerateUserCredentials</PackageId>
     <Version>1.0.0</Version>

--- a/Google.Ads.GoogleAds/examples/Google.Ads.GoogleAds.Examples.csproj
+++ b/Google.Ads.GoogleAds/examples/Google.Ads.GoogleAds.Examples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1;net8.0</TargetFrameworks>
     <RootNamespace>Google.Ads.GoogleAds.Examples</RootNamespace>
     <AssemblyName>Google.Ads.GoogleAds.Examples</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Google.Ads.GoogleAds/src/Google.Ads.GoogleAds.csproj
+++ b/Google.Ads.GoogleAds/src/Google.Ads.GoogleAds.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <!-- build properties -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472;net8.0</TargetFrameworks>
     <AssemblyName>Google.Ads.GoogleAds</AssemblyName>
     <RootNamespace>Google.Ads.GoogleAds</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/Google.Ads.GoogleAds/tests/Google.Ads.GoogleAds.Tests.csproj
+++ b/Google.Ads.GoogleAds/tests/Google.Ads.GoogleAds.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Google.Ads.GoogleAds.Tests</RootNamespace>
     <AssemblyName>Google.Ads.GoogleAds.Tests</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
.NET 6.0 has been out of support from Microsoft since last year.

Besides, targeting `netstandard2.1` also includes support for .NET 6.0 (see [here](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1)) and we don't use any language features specific of .NET 6.0, so we didn't actually need the explicit targeting anyway.