### PR TITLE
Remove masking the FeedPlaceholderEmailAddress field from logs

### DIFF
--- a/Google.Ads.GoogleAds.Core/src/Lib/MetadataKeyNames.cs
+++ b/Google.Ads.GoogleAds.Core/src/Lib/MetadataKeyNames.cs
@@ -78,12 +78,6 @@ namespace Google.Ads.GoogleAds.Lib
         internal const string ChangeEventUserEmail = "change_event.user_email";
 
         /// <summary>
-        /// The metadata key name for the Feed placeholder email address.
-        /// </summary>
-        internal const string FeedPlaceholderEmailAddress =
-            "feed.places_location_feed_data.email_address";
-
-        /// <summary>
         /// The metadata key name for the Local services lead contact details.
         /// </summary>
         internal const string LocalServicesLeadContactDetails =

--- a/Google.Ads.GoogleAds.Core/src/Logging/LogFormatter.cs
+++ b/Google.Ads.GoogleAds.Core/src/Logging/LogFormatter.cs
@@ -43,7 +43,6 @@ namespace Google.Ads.GoogleAds.Logging
                 MetadataKeyNames.CustomerUserAccessInviterEmailAddress,
                 MetadataKeyNames.CustomerUserAccessEmailAddress,
                 MetadataKeyNames.ChangeEventUserEmail,
-                MetadataKeyNames.FeedPlaceholderEmailAddress,
                 MetadataKeyNames.CustomerUserAccessInvitationEmailAddress,
                 MetadataKeyNames.LocalServicesLeadContactDetails,
                 MetadataKeyNames.LocalServicesLeadConversationMessageDetailText,


### PR DESCRIPTION
The FeedPlaceholderEmailAddress was only present up to V18, which has now sunset, so we don't need to mask it in logs anymore.