### PR TITLE
Removed unused parameter from ResourceNames.AssetSet

### DIFF
--- a/Google.Ads.GoogleAds/src/V19/ResourceNames.cs
+++ b/Google.Ads.GoogleAds/src/V19/ResourceNames.cs
@@ -209,7 +209,7 @@ namespace Google.Ads.GoogleAds.V19.Errors
             return $"customers/{customerId}/assetGroupSignals/{assetGroupIdCriterionId}";
         }
 
-        public static string AssetSet(long customerId, long assetSetId, long assetId)
+        public static string AssetSet(long customerId, long assetSetId)
         {
             return $"customers/{customerId}/assetSets/{assetSetId}";
         }

--- a/Google.Ads.GoogleAds/src/V20/ResourceNames.cs
+++ b/Google.Ads.GoogleAds/src/V20/ResourceNames.cs
@@ -209,7 +209,7 @@ namespace Google.Ads.GoogleAds.V20.Errors
             return $"customers/{customerId}/assetGroupSignals/{assetGroupIdCriterionId}";
         }
 
-        public static string AssetSet(long customerId, long assetSetId, long assetId)
+        public static string AssetSet(long customerId, long assetSetId)
         {
             return $"customers/{customerId}/assetSets/{assetSetId}";
         }

--- a/Google.Ads.GoogleAds/src/V21/ResourceNames.cs
+++ b/Google.Ads.GoogleAds/src/V21/ResourceNames.cs
@@ -209,7 +209,7 @@ namespace Google.Ads.GoogleAds.V21.Errors
             return $"customers/{customerId}/assetGroupSignals/{assetGroupIdCriterionId}";
         }
 
-        public static string AssetSet(long customerId, long assetSetId, long assetId)
+        public static string AssetSet(long customerId, long assetSetId)
         {
             return $"customers/{customerId}/assetSets/{assetSetId}";
         }

--- a/Google.Ads.GoogleAds/src/V22/ResourceNames.cs
+++ b/Google.Ads.GoogleAds/src/V22/ResourceNames.cs
@@ -210,7 +210,7 @@ namespace Google.Ads.GoogleAds.V22.Errors
             return $"customers/{customerId}/assetGroupSignals/{assetGroupIdCriterionId}";
         }
 
-        public static string AssetSet(long customerId, long assetSetId, long assetId)
+        public static string AssetSet(long customerId, long assetSetId)
         {
             return $"customers/{customerId}/assetSets/{assetSetId}";
         }


### PR DESCRIPTION
This fixes #579.

A previously closed PR (#580) addressed the issue for other API versions, however this issue has reoccurred in V19-V22.
